### PR TITLE
Replace pub get with flutter pub get

### DIFF
--- a/.buildconfig
+++ b/.buildconfig
@@ -1,0 +1,10 @@
+[default]
+name=Default
+runtime=host
+config-opts=
+run-opts=
+prefix=/home/nmcain/.cache/gnome-builder/install/assets/host
+app-id=
+postbuild=
+prebuild=
+default=true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/hayderux/electron-quick-start-flutter
 # Go into the repository
 cd electron-quick-start-flutter
 #install flutter dependencies
-pub get
+flutter pub get
 # Install dependencies
 npm install
 # Run the app

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,45 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/bin/node', '/usr/bin/npm', 'run', 'dev' ]
+2 info using npm@3.5.2
+3 info using node@v8.10.0
+4 verbose run-script [ 'predev', 'dev', 'postdev' ]
+5 info lifecycle electron-quick-start-flutter@1.0.0~predev: electron-quick-start-flutter@1.0.0
+6 silly lifecycle electron-quick-start-flutter@1.0.0~predev: no script for predev, continuing
+7 info lifecycle electron-quick-start-flutter@1.0.0~dev: electron-quick-start-flutter@1.0.0
+8 verbose lifecycle electron-quick-start-flutter@1.0.0~dev: unsafe-perm in lifecycle true
+9 verbose lifecycle electron-quick-start-flutter@1.0.0~dev: PATH: /usr/share/npm/bin/node-gyp-bin:/home/nmcain/Desktop/electron-quick-start-flutter/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/nmcain/flutter/bin
+10 verbose lifecycle electron-quick-start-flutter@1.0.0~dev: CWD: /home/nmcain/Desktop/electron-quick-start-flutter
+11 silly lifecycle electron-quick-start-flutter@1.0.0~dev: Args: [ '-c', 'run-p "build_runner_serve" "start"' ]
+12 silly lifecycle electron-quick-start-flutter@1.0.0~dev: Returned: code: 1  signal: null
+13 info lifecycle electron-quick-start-flutter@1.0.0~dev: Failed to exec dev script
+14 verbose stack Error: electron-quick-start-flutter@1.0.0 dev: `run-p "build_runner_serve" "start"`
+14 verbose stack Exit status 1
+14 verbose stack     at EventEmitter.<anonymous> (/usr/share/npm/lib/utils/lifecycle.js:232:16)
+14 verbose stack     at emitTwo (events.js:126:13)
+14 verbose stack     at EventEmitter.emit (events.js:214:7)
+14 verbose stack     at ChildProcess.<anonymous> (/usr/share/npm/lib/utils/spawn.js:24:14)
+14 verbose stack     at emitTwo (events.js:126:13)
+14 verbose stack     at ChildProcess.emit (events.js:214:7)
+14 verbose stack     at maybeClose (internal/child_process.js:925:16)
+14 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
+15 verbose pkgid electron-quick-start-flutter@1.0.0
+16 verbose cwd /home/nmcain/Desktop/electron-quick-start-flutter
+17 error Linux 5.0.0-31-generic
+18 error argv "/usr/bin/node" "/usr/bin/npm" "run" "dev"
+19 error node v8.10.0
+20 error npm  v3.5.2
+21 error code ELIFECYCLE
+22 error electron-quick-start-flutter@1.0.0 dev: `run-p "build_runner_serve" "start"`
+22 error Exit status 1
+23 error Failed at the electron-quick-start-flutter@1.0.0 dev script 'run-p "build_runner_serve" "start"'.
+23 error Make sure you have the latest version of node.js and npm installed.
+23 error If you do, this is most likely a problem with the electron-quick-start-flutter package,
+23 error not with npm itself.
+23 error Tell the author that this fails on your system:
+23 error     run-p "build_runner_serve" "start"
+23 error You can get information on how to open an issue for this project with:
+23 error     npm bugs electron-quick-start-flutter
+23 error Or if that isn't available, you can get their info via:
+23 error     npm owner ls electron-quick-start-flutter
+23 error There is likely additional logging output above.
+24 verbose exit [ 1, true ]


### PR DESCRIPTION
Many users do not have flutter and dart installed as seperate sdks, for sake of efficiency, use flutter pub get instead